### PR TITLE
v0.0.8

### DIFF
--- a/examples/05-fsm.janet
+++ b/examples/05-fsm.janet
@@ -6,17 +6,20 @@
 # The goto method is used to transition between states.
 # the Enter and Leave methods are optional, and are called during the
 # GOTO method.
+#
+# any additional arguments passed into the goto method will be passed in
+# to the Enter method.
 (fsm/define
   colored-warnings
   {:green
    {:enter (fn [self] (print "entering green"))
     :leave (fn [self] (print "leaving green"))
-    :warn (fn [self]
+    :warn (fn [self name]
             (print "before warn")
-            (:goto self :yellow)
+            (:goto self :yellow name)
             (print "after warn") :)}
    :yellow
-   {:enter (fn [self] (print "entering yellow"))
+   {:enter (fn [self name] (printf "entering yellow, %s be careful!" name))
     :panic |(:goto $ :red)
     :clear |(:goto $ :green)}
    :red
@@ -28,7 +31,7 @@
 (print "Example 1 output:")
 (def *state* (colored-warnings :green))
 (print "start: " (*state* :current))
-(:warn *state*)
+(:warn *state* "Alec")
 (:panic *state*)
 (:calm *state*)
 (:clear *state*)

--- a/junk-drawer/ecs.janet
+++ b/junk-drawer/ecs.janet
@@ -35,14 +35,15 @@
 
 (defmacro add-entity [world & components]
   "Add a new entity with the given components to the world."
-  (with-syms [$id $db]
-    ~(let [,$id (get world :id-counter)
-           ,$db (get world :database)]
+  (with-syms [$id $db $wld]
+    ~(let [,$wld ,world
+           ,$id (get ,$wld :id-counter)
+           ,$db (get ,$wld :database)]
        (put-in ,$db [:entity ,$id] ,$id)
        ,;(map
            |(quasiquote (put-in ,$db [,(keyword (first $)) ,$id] ,$))
            components)
-       (put world :id-counter (inc ,$id))
+       (put ,$wld :id-counter (inc ,$id))
        ,$id)))
 
 (defn remove-entity [world ent]
@@ -51,9 +52,10 @@
     (put components ent nil)))
 
 (defmacro add-component [world ent component]
-  ~(do
-     (assert (get-in ,world [:database :entity ,ent]) "entity does not exist in world")
-     (put-in ,world [:database ,(keyword (first component)) ,ent] ,component)))
+  (with-syms [$wld]
+    ~(let [,$wld ,world]
+       (assert (get-in ,$wld [:database :entity ,ent]) "entity does not exist in world")
+       (put-in ,$wld [:database ,(keyword (first component)) ,ent] ,component))))
 
 (defn remove-component [world ent component-name]
   (assert (get-in world [:database :entity ent]) "entity does not exist in world")

--- a/junk-drawer/fsm.janet
+++ b/junk-drawer/fsm.janet
@@ -1,4 +1,4 @@
-(defn- goto [self to]
+(defn- goto [self to & args]
   (assert (self to) (string/format "%q is not a valid state" to))
 
   # Call leave method on old state
@@ -21,7 +21,7 @@
 
   # call enter on new state
   (when (self :enter)
-    (:enter self)))
+    (:enter self ;args)))
 
 
 (defmacro define [name states]

--- a/junk-drawer/messages.janet
+++ b/junk-drawer/messages.janet
@@ -12,11 +12,13 @@
 
 (defmacro send [world content & tags]
   "create a message entity with content & the tag components"
-  ~(add-entity ,world
-                (message :content ,content
-                         :consumed false
-                         :created (os/clock))
-                ,;(map |(tuple $) tags)))
+  (with-syms [$wld]
+    ~(let [,$wld ,world]
+       (add-entity ,$wld
+                    (message :content ,content
+                             :consumed false
+                             :created (os/clock))
+                    ,;(map |(tuple $) tags)))))
 
 (defn consume [msg]
   (put msg :consumed true))

--- a/junk-drawer/messages.janet
+++ b/junk-drawer/messages.janet
@@ -15,7 +15,7 @@
   ~(add-entity ,world
                 (message :content ,content
                          :consumed false
-                         :created (os/time))
+                         :created (os/clock))
                 ,;(map |(tuple $) tags)))
 
 (defn consume [msg]


### PR DESCRIPTION
- replace `os/time` with `os/clock` for finer resolution in messages `created` field
- uses gensyms for world variable in `ecs/add-component`, `ecs/add-entity` and `messages/send` macros. 
- allow additional args to be passed into the enter function in fsm through goto