### PR TITLE
refactor stress test macros

### DIFF
--- a/test/performance/stress-test.janet
+++ b/test/performance/stress-test.janet
@@ -16,29 +16,26 @@
   "Define and register a system with 2 queries, each with 2 alphabet components."
   (array/concat
     # define system
-    (map (fn [i]
-           ['def-system (symbol "sys-" i)
-            ~{first [,(keyword (ALPHABET i)) ,(keyword (ALPHABET (% (+ 1 i) 25)))]
-              second [,(keyword (ALPHABET (% (+ 2 i) 25))) ,(keyword (ALPHABET (% (+ 3 i) 25)))]}
-            nil])
+    (map |['def-system (symbol "sys-" $)
+           ~{first [,(keyword (ALPHABET $)) ,(keyword (ALPHABET (% (+ 1 $) 25)))]
+             second [,(keyword (ALPHABET (% (+ 2 $) 25))) ,(keyword (ALPHABET (% (+ 3 $) 25)))]}
+           nil]
          (range 0 25))
 
     # Register it
-    (map (fn [i] ['register-system 'world (symbol "sys-" i)])
+    (map |['register-system 'world (symbol "sys-" $)]
          (range 0 25))))
 
 (defmacro create-entities-alphabet []
   "Define a entity for every letter and letter+1 components."
-  (map (fn [i]
-         ['add-entity 'world
-          [(symbol (ALPHABET i)) :val i]
-          [(symbol (ALPHABET (% (+ 1 i) 25))) :val i]])
+  (map |['add-entity 'world
+         [(symbol (ALPHABET $)) :val $]
+         [(symbol (ALPHABET (% (inc $) 25))) :val $]]
        (range 0 25)))
 
 (defmacro create-a-lot-of-entites []
   "Create A LOT of entities by calling create-entities-alphabet lots of times"
-  (map (fn [i] ['create-entities-alphabet]) # each one of these creates 26 entities
-       (range 0 100))) # so lets call it 100 times for 2600 entites
+  (array/new-filled 100 ['create-entities-alphabet]))
 
 (print "lets create all the things")
 (def world (create-world))

--- a/test/performance/stress-test.janet
+++ b/test/performance/stress-test.janet
@@ -1,5 +1,4 @@
 # run with 'time janet stress-test.janet'
-# NOTE: the macros here and incredibly unhygenic with probably a lot of accidental binding bapture!
 
 (use /junk-drawer)
 

--- a/test/performance/stress-test.janet
+++ b/test/performance/stress-test.janet
@@ -3,48 +3,44 @@
 
 (use /junk-drawer)
 
-(var ALPHABET ["a" "b" "c" "d" "e" "f" "g" "h" "i"
+(def ALPHABET ["a" "b" "c" "d" "e" "f" "g" "h" "i"
                "j" "k" "l" "m" "n" "o" "p" "q" "r"
                "s" "t" "u" "v" "w" "x" "y" "z"])
 
 (defmacro def-component-alphabet []
   "Define a component for every letter of the alphabet."
-  ~(upscope
-    ,;(map |(tuple ~def-component (symbol $) :val :number)
-           ALPHABET)))
+  (map |['def-component (symbol $) :val :number]
+       ALPHABET))
 
 (defmacro def-systems-alphabet []
   "Define and register a system with 2 queries, each with 2 alphabet components."
-  ~(upscope
+  (array/concat
     # define system
-    ,;(map (fn [i]
-             (tuple ~def-system (symbol "sys-" i)
-                     ~{first [,(keyword (ALPHABET i)) ,(keyword (ALPHABET (% (+ 1 i) 25)))]
-                       second[,(keyword (ALPHABET (% (+ 2 i) 25))) ,(keyword (ALPHABET (% (+ 3 i) 25)))]}
-                     ~nil))
-           (range 0 25))
+    (map (fn [i]
+           ['def-system (symbol "sys-" i)
+            ~{first [,(keyword (ALPHABET i)) ,(keyword (ALPHABET (% (+ 1 i) 25)))]
+              second [,(keyword (ALPHABET (% (+ 2 i) 25))) ,(keyword (ALPHABET (% (+ 3 i) 25)))]}
+            nil])
+         (range 0 25))
 
     # Register it
-    ,;(map (fn [i] (tuple ~register-system ~world (symbol "sys-" i)))
-           (range 0 25))
-    ))
+    (map (fn [i] ['register-system 'world (symbol "sys-" i)])
+         (range 0 25))))
 
 (defmacro create-entities-alphabet []
   "Define a entity for every letter and letter+1 components."
-  ~(upscope
-    ,;(map (fn [i]
-             (tuple ~add-entity ~world
-                     ~(,(symbol (ALPHABET i)) :val ,i)
-                     ~(,(symbol (ALPHABET (% (+ 1 i) 25))) :val ,i)))
-           (range 0 25))))
+  (map (fn [i]
+         ['add-entity 'world
+          [(symbol (ALPHABET i)) :val i]
+          [(symbol (ALPHABET (% (+ 1 i) 25))) :val i]])
+       (range 0 25)))
 
 (defmacro create-a-lot-of-entites []
   "Create A LOT of entities by calling create-entities-alphabet lots of times"
-  ~(upscope
-    ,;(map (fn [i] (tuple ~create-entities-alphabet)) # each one of these creates 26 entities
-           (range 0 100)))) # so lets call it 100 times for 2600 entites
+  (map (fn [i] ['create-entities-alphabet]) # each one of these creates 26 entities
+       (range 0 100))) # so lets call it 100 times for 2600 entites
 
-(pp "lets create all the things")
+(print "lets create all the things")
 (def world (create-world))
 
 (def-component-alphabet)
@@ -61,7 +57,7 @@
               (a :val 1)
               (b :val 1)))
 
-(pp "everything created, lets run update")
+(print "everything created, lets run update")
 (for i 0 1000
   (when (= 0 (% i 100))
     (printf "i=%q" i))
@@ -74,3 +70,5 @@
 
   (when (= 0 (% i 20))
     (create-random-entity)))
+
+(print "everything done")

--- a/test/performance/stress-test.janet
+++ b/test/performance/stress-test.janet
@@ -17,7 +17,7 @@
   (array/concat
     # define system
     (map |['def-system (symbol "sys-" $)
-           ~{first [,(keyword (ALPHABET $)) ,(keyword (ALPHABET (% (+ 1 $) 25)))]
+           ~{first [,(keyword (ALPHABET $)) ,(keyword (ALPHABET (% (inc $) 25)))]
              second [,(keyword (ALPHABET (% (+ 2 $) 25))) ,(keyword (ALPHABET (% (+ 3 $) 25)))]}
            nil]
          (range 0 25))


### PR DESCRIPTION
Some code design changes:
- remove upscopes
- do not quote result arrays
- change quasiquote ~ to quote ', where it is not needed
- make ALPHABET constant
- change log prints from pp to print and add final one