### PR TITLE
use spork schema for component macro

### DIFF
--- a/examples/01-ecs.janet
+++ b/examples/01-ecs.janet
@@ -1,9 +1,9 @@
 (use /junk-drawer)
 
 # Register (global) components, these are shared across worlds.
-# the types given can by any of the ones listed here https://janet-lang.org/api/index.html#type
-# or ":any", for any type!
-# components use a table like syntax
+# Components create tables by listing keyname type-schema.
+# The type-schema given can by any form of the syntax listed in spork/schema
+# https://github.com/janet-lang/spork/blob/master/spork/schema.janet#L17
 (def-component position :x :number :y :number)
 (def-component velocity :x :number :y :number)
 (def-component lives :count :number)

--- a/junk-drawer/ecs.janet
+++ b/junk-drawer/ecs.janet
@@ -1,23 +1,13 @@
+(use spork/schema)
+
 (import /junk-drawer/sparse-set)
 (import /junk-drawer/cache)
 
 (defmacro def-component [name & fields]
   "Define a new component with the specified fields."
-  (let [type-table (table ;fields)
-        def-array (mapcat |[$ (symbol $)] (keys type-table))]
-    ~(defn ,name [&keys ,(struct ;def-array)]
-       # assert types of the component fields
-       ,;(map
-          (fn [[key field-type]]
-            ~(assert
-              (= (type ,(symbol key)) ,field-type)
-              ,(string/format "%q must be of type %q" key field-type)))
-          (filter
-           |(not= (last $) :any)
-           (pairs type-table)))
-
-       # return the component
-       ,(table ;def-array))))
+  ~(defn ,name [&named ,;(map |(symbol $) (keys (table ;fields)))]
+     ((,(make-validator ~(props ,;fields)))
+       ,(table ;(mapcat |[$ (symbol $)] (keys (table ;fields)))))))
 
 (defmacro def-tag [name]
   "Define a new tag (component with no data)."


### PR DESCRIPTION
closes #28 

actually ended up being simpler then I expected. Now you can do stuff like this

```janet
(def-component complicated
  :a :string
  :b (or :number :nil)
  :c (props :d :keyword)
  :e (and :array (length 0 3))
  :f (and :number (pred |(> $ 4))))
```