### PR TITLE
Envelopes round 2, plus a bug fix in Tweens

### DIFF
--- a/examples/10-envelopes.janet
+++ b/examples/10-envelopes.janet
@@ -14,7 +14,7 @@
                :release-duration 15 :release-tween tweens/in-out-quad))
 
 # call begin on adsr to move it off the :idle  state
-(:begin *adsr*)
+(:trigger *adsr*)
 
 # call tick to iterate to the next step.. though we'll get trapped in the sustain state
 (for i 0 40 (print-bar (:tick *adsr*)))
@@ -25,3 +25,4 @@
 (for i 0 15 (print-bar (:tick *adsr*)))
 
 # There are also the simpler ASR and AR envelopes.
+# ALSO, you can release or (re)trigger early from any relevent state

--- a/examples/12-envelopes-visualizer.janet
+++ b/examples/12-envelopes-visualizer.janet
@@ -1,0 +1,33 @@
+(use jaylib)
+(use /junk-drawer)
+
+(init-window 800 480 "Envelopes Visualizer")
+(set-target-fps 30)
+(hide-cursor)
+
+(var *adsr* (envelopes/adsr
+             :attack-target 200 :attack-duration 60 :attack-tween tweens/in-linear
+             :decay-target 120 :decay-duration 40
+             :release-duration 100 :release-tween tweens/in-out-quad))
+
+(:trigger *adsr*)
+
+(begin-drawing)
+(clear-background 0x222034ff)
+
+(for i 0 100
+  (draw-circle (+ 20 (* i 4))
+               (math/round (- 400 (:tick *adsr*)))
+               3 0xcbdbfcff))
+
+(:release *adsr*)
+
+(for i 100 200
+  (draw-circle (+ 20 (* i 4))
+               (math/round (- 400 (:tick *adsr*)))
+               3 0xcbdbfcff))
+(end-drawing)
+
+(while (not (window-should-close)) nil)
+
+(close-window)

--- a/examples/12-envelopes-visualizer.janet
+++ b/examples/12-envelopes-visualizer.janet
@@ -1,31 +1,36 @@
 (use jaylib)
 (use /junk-drawer)
 
-(init-window 800 480 "Envelopes Visualizer")
+(init-window 1000 480 "Envelopes Visualizer")
 (set-target-fps 30)
 (hide-cursor)
 
 (var *adsr* (envelopes/adsr
-             :attack-target 200 :attack-duration 60 :attack-tween tweens/in-linear
+             :attack-target 200 :attack-duration 60 :attack-tween tweens/out-linear
              :decay-target 120 :decay-duration 40
-             :release-duration 100 :release-tween tweens/in-out-quad))
+             :release-duration 50 :release-tween tweens/in-out-quad))
 
 (:trigger *adsr*)
 
 (begin-drawing)
 (clear-background 0x222034ff)
 
-(for i 0 100
+(for i 0 150
   (draw-circle (+ 20 (* i 4))
                (math/round (- 400 (:tick *adsr*)))
-               3 0xcbdbfcff))
+               3
+               (match (*adsr* :current)
+                 :idle 0xcbdbfcff
+                 :attack 0x99e550ff
+                 :decay 0xd95763ff
+                 :sustain 0x5fcde4ff)))
 
 (:release *adsr*)
 
-(for i 100 200
+(for i 150 200
   (draw-circle (+ 20 (* i 4))
                (math/round (- 400 (:tick *adsr*)))
-               3 0xcbdbfcff))
+               3 0xfbf236ff))
 (end-drawing)
 
 (while (not (window-should-close)) nil)

--- a/junk-drawer/envelopes.janet
+++ b/junk-drawer/envelopes.janet
@@ -21,15 +21,16 @@ All envelopes have the same api. Create them with their constructor, then use th
 (defn- attack-state [target duration &opt tween]
   (default tween tweens/in-linear)
   (fsm/state :attack
+     :start 0
      :target target
      :elapsed 0
      :duration duration
      :complete? (fn attack-complete [self]
-                  (>= (self :elapsed)
-                      (self :duration)))
+                  (> (self :elapsed)
+                     (self :duration)))
      :next-value (fn attack-next-value [self]
                    (tweens/interpolate
-                    (self :value)
+                    (self :start)
                     (self :target)
                     (self :elapsed)
                     (self :duration)
@@ -42,11 +43,11 @@ All envelopes have the same api. Create them with their constructor, then use th
      :elapsed 0
      :duration duration
      :complete? (fn decay-complete [self]
-                  (>= (self :elapsed)
-                      (self :duration)))
+                  (> (self :elapsed)
+                     (self :duration)))
      :next-value (fn decay-next-value [self]
                    (tweens/interpolate
-                    (self :value)
+                    (self :start)
                     (self :target)
                     (self :elapsed)
                     (self :duration)
@@ -65,11 +66,11 @@ All envelopes have the same api. Create them with their constructor, then use th
      :elapsed 0
      :duration duration
      :complete? (fn release-complete [self]
-                  (>= (self :elapsed)
-                      (self :duration)))
+                  (> (self :elapsed)
+                     (self :duration)))
      :next-value (fn release-next-value [self]
                    (tweens/interpolate
-                    (self :value)
+                    (self :start)
                     (self :target)
                     (self :elapsed)
                     (self :duration)
@@ -89,9 +90,10 @@ All envelopes have the same api. Create them with their constructor, then use th
 
     (when-let [state-complete? (:complete? self)
                auto-fn (get self :auto false)
-               target (get self :target new-value)]
+               next-start (get self :target new-value)]
       (:auto self)
-      (put self :value target))
+      (put self :start next-start)
+      (put self :value next-start))
 
     (self :value)))
 
@@ -100,9 +102,9 @@ All envelopes have the same api. Create them with their constructor, then use th
    fsm/FSM
    @{:tick tick
      :current :idle
-     :value 0
+       :value 0
      :__id__ :envelope
-     :__validate__ (fn [& args] true)}))
+       :__validate__ (fn [& args] true)}))
 
 (defmacro- defn-envelope [name docs args & body]
   ~(defn ,name

--- a/junk-drawer/envelopes.janet
+++ b/junk-drawer/envelopes.janet
@@ -21,7 +21,6 @@ All envelopes have the same api. Create them with their constructor, then use th
 (defn- attack-state [target duration &opt tween]
   (default tween tweens/in-linear)
   (fsm/state :attack
-     :value 0
      :target target
      :elapsed 0
      :duration duration
@@ -78,7 +77,6 @@ All envelopes have the same api. Create them with their constructor, then use th
 
 (defn- idle-state []
   (fsm/state :idle
-     :value 0
      :elapsed 0
      :complete? (fn idle-complete? [self] false)
      :next-value (fn idle-next-value [self] 0)))
@@ -102,8 +100,9 @@ All envelopes have the same api. Create them with their constructor, then use th
    fsm/FSM
    @{:tick tick
      :current :idle
-       :__id__ :envelope
-       :__validate__ (fn [& args] true)}))
+     :value 0
+     :__id__ :envelope
+     :__validate__ (fn [& args] true)}))
 
 (defmacro- defn-envelope [name docs args & body]
   ~(defn ,name

--- a/test/unit/envelopes-test.janet
+++ b/test/unit/envelopes-test.janet
@@ -8,7 +8,7 @@
              :release-duration 10)]
   (test/assert (= (*ar* :current) :idle) "AR starts in idle")
 
-  (:begin *ar*)
+  (:trigger *ar*)
   (test/assert (= (*ar* :current) :attack) "AR attack after begin")
 
   (for i 0 10 (:tick *ar*))
@@ -27,7 +27,7 @@
              :release-duration 10)]
   (test/assert (= (*asr* :current) :idle) "ASR starts in idle")
 
-  (:begin *asr*)
+  (:trigger *asr*)
   (test/assert (= (*asr* :current) :attack) "ASR attack after begin")
 
   (for i 0 10 (:tick *asr*))
@@ -54,7 +54,7 @@
              :release-duration 10)]
   (test/assert (= (*adsr* :current) :idle) "ADSR starts in idle")
 
-  (:begin *adsr*)
+  (:trigger *adsr*)
   (test/assert (= (*adsr* :current) :attack) "ADSR attack after begin")
 
   (for i 0 10 (:tick *adsr*))

--- a/test/unit/envelopes-test.janet
+++ b/test/unit/envelopes-test.janet
@@ -3,13 +3,14 @@
 
 # AR
 (test/start-suite 0)
+# Lets go through all the states
 (let [*ar* (envelopes/ar
              :attack-target 10 :attack-duration 10
              :release-duration 10)]
   (test/assert (= (*ar* :current) :idle) "AR starts in idle")
 
   (:trigger *ar*)
-  (test/assert (= (*ar* :current) :attack) "AR attack after begin")
+  (test/assert (= (*ar* :current) :attack) "AR attack after triggering from idle")
 
   (for i 0 10 (:tick *ar*))
   (test/assert (= (*ar* :value) 10) "AR end of attack is 10")
@@ -18,10 +19,34 @@
   (for i 0 10 (:tick *ar*))
   (test/assert (= (*ar* :value) 0) "AR end of release is 0")
   (test/assert (= (*ar* :current) :idle) "AR idle after 10 ticks of release"))
+
+# Make sure we can re-trigger from both states
+(let [*ar* (envelopes/ar
+            :attack-target 10 :attack-duration 2
+            :release-duration 10)]
+  (:trigger *ar*)
+  (:trigger *ar*)
+  (test/assert (= (*ar* :current) :attack) "AR attack after (re)triggering from trigger")
+
+  (for i 0 3 (:tick *ar*))
+  (:trigger *ar*)
+  (test/assert (= (*ar* :current) :attack) "AR attack after triggering from release"))
+
+# Make sure we  can release early
+(let [*ar* (envelopes/ar
+            :attack-target 10 :attack-duration 10
+            :release-duration 10)]
+  (:trigger *ar*)
+
+  (for i 0 3 (:tick *ar*)) # still in attack after just 3 ticks
+  (:release *ar*)
+  (test/assert (= (*ar* :current) :release) "AR release after releasing early in :attack"))
 (test/end-suite)
 
 # ASR
 (test/start-suite 1)
+
+# Test going through all the states
 (let [*asr* (envelopes/asr
              :attack-target 10 :attack-duration 10
              :release-duration 10)]
@@ -43,10 +68,40 @@
   (for i 0 10 (:tick *asr*))
   (test/assert (= (*asr* :value) 0) "ASR end of relase is 0")
   (test/assert (= (*asr* :current) :idle) "ASR idle after 10 ticks of release"))
+
+# Test (re)triggering from all the states
+(let [*asr* (envelopes/asr
+             :attack-target 10 :attack-duration 10
+             :release-duration 10)]
+  (:goto *asr* :attack)
+  (:trigger *asr*)
+  (test/assert (= (*asr* :current) :attack) "ASR attack after triggering from attack")
+
+  (:goto *asr* :sustain)
+  (:trigger *asr*)
+  (test/assert (= (*asr* :current) :attack) "ASR attack after triggering from sustain")
+
+  (:goto *asr* :release)
+  (:trigger *asr*)
+  (test/assert (= (*asr* :current) :attack) "ASR attack after triggering from release"))
+
+# Test releasing early
+(let [*asr* (envelopes/asr
+             :attack-target 10 :attack-duration 10
+             :release-duration 10)]
+  (:goto *asr* :attack)
+  (:release *asr*)
+  (test/assert (= (*asr* :current) :release) "ASR release after triggering from attack")
+
+  (:goto *asr* :sustain)
+  (:release *asr*)
+  (test/assert (= (*asr* :current) :release) "ASR release after triggering from sustain"))
 (test/end-suite)
 
 # ADSR
 (test/start-suite 2)
+
+# Test going through all the states
 (let [*adsr* (envelopes/adsr
              :attack-target 10 :attack-duration 10
              :decay-target 5 :decay-duration 10
@@ -60,7 +115,6 @@
   (for i 0 10 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 10) "ADSR end of attack is 10")
   (test/assert (= (*adsr* :current) :decay) "ADSR decay after 10 ticks of attack")
-
 
   (for i 0 10 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 5) "ADSR end of decay is 5")
@@ -76,4 +130,44 @@
   (for i 0 10 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 0) "ADSR end of sustain is 0")
   (test/assert (= (*adsr* :current) :idle) "ADSR idle after 10 ticks of release"))
+
+# Test (re)triggering from all the states
+(let [*adsr* (envelopes/adsr
+              :attack-target 10 :attack-duration 10
+              :decay-target 5 :decay-duration 10
+              :sustain-duration 10
+              :release-duration 10)]
+  (:goto *adsr* :attack)
+  (:trigger *adsr*)
+  (test/assert (= (*adsr* :current) :attack) "ADSR attack after triggering from attack")
+
+  (:goto *adsr* :decay)
+  (:trigger *adsr*)
+  (test/assert (= (*adsr* :current) :attack) "ADSR attack after triggering from decay")
+
+  (:goto *adsr* :sustain)
+  (:trigger *adsr*)
+  (test/assert (= (*adsr* :current) :attack) "ADSR attack after triggering from sustain")
+
+  (:goto *adsr* :release)
+  (:trigger *adsr*)
+  (test/assert (= (*adsr* :current) :attack) "ADSR attack after triggering from release"))
+
+# Test releasing early
+(let [*adsr* (envelopes/adsr
+              :attack-target 10 :attack-duration 10
+              :decay-target 5 :decay-duration 10
+              :sustain-duration 10
+              :release-duration 10)]
+  (:goto *adsr* :attack)
+  (:release *adsr*)
+  (test/assert (= (*adsr* :current) :release) "ADSR release after triggering from attack")
+
+  (:goto *adsr* :decay)
+  (:release *adsr*)
+  (test/assert (= (*adsr* :current) :release) "ADSR release after triggering from decay")
+
+  (:goto *adsr* :sustain)
+  (:release *adsr*)
+  (test/assert (= (*adsr* :current) :release) "ADSR release after triggering from sustain"))
 (test/end-suite)

--- a/test/unit/envelopes-test.janet
+++ b/test/unit/envelopes-test.janet
@@ -12,11 +12,11 @@
   (:trigger *ar*)
   (test/assert (= (*ar* :current) :attack) "AR attack after triggering from idle")
 
-  (for i 0 10 (:tick *ar*))
+  (for i 0 11 (:tick *ar*))
   (test/assert (= (*ar* :value) 10) "AR end of attack is 10")
   (test/assert (= (*ar* :current) :release) "AR release after 10 ticks of attack")
 
-  (for i 0 10 (:tick *ar*))
+  (for i 0 11 (:tick *ar*))
   (test/assert (= (*ar* :value) 0) "AR end of release is 0")
   (test/assert (= (*ar* :current) :idle) "AR idle after 10 ticks of release"))
 
@@ -55,7 +55,7 @@
   (:trigger *asr*)
   (test/assert (= (*asr* :current) :attack) "ASR attack after begin")
 
-  (for i 0 10 (:tick *asr*))
+  (for i 0 11 (:tick *asr*))
   (test/assert (= (*asr* :value) 10) "ASR end of attack is 10")
   (test/assert (= (*asr* :current) :sustain) "ASR sustain after 10 ticks of attack")
 
@@ -65,7 +65,7 @@
   (:release *asr*)
   (test/assert (= (*asr* :current) :release) "ASR release after calling :release")
 
-  (for i 0 10 (:tick *asr*))
+  (for i 0 11 (:tick *asr*))
   (test/assert (= (*asr* :value) 0) "ASR end of relase is 0")
   (test/assert (= (*asr* :current) :idle) "ASR idle after 10 ticks of release"))
 
@@ -112,22 +112,22 @@
   (:trigger *adsr*)
   (test/assert (= (*adsr* :current) :attack) "ADSR attack after begin")
 
-  (for i 0 10 (:tick *adsr*))
+  (for i 0 11 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 10) "ADSR end of attack is 10")
   (test/assert (= (*adsr* :current) :decay) "ADSR decay after 10 ticks of attack")
 
-  (for i 0 10 (:tick *adsr*))
+  (for i 0 11 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 5) "ADSR end of decay is 5")
   (test/assert (= (*adsr* :current) :sustain) "ADSR sustain after 10 ticks of decay")
 
 
-  (for i 0 10 (:tick *adsr*))
+  (for i 0 11 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 5) "ADSR sustain is still 5")
   (test/assert (= (*adsr* :current) :sustain) "AdSR still in sustain")
   (:release *adsr*)
   (test/assert (= (*adsr* :current) :release) "AdSR release after calling :release")
 
-  (for i 0 10 (:tick *adsr*))
+  (for i 0 11 (:tick *adsr*))
   (test/assert (= (*adsr* :value) 0) "ADSR end of sustain is 0")
   (test/assert (= (*adsr* :current) :idle) "ADSR idle after 10 ticks of release"))
 


### PR DESCRIPTION
Definitely merged the first round of envelopes too early.. I should have opened up my DAW and really explored the Envelopes instead of just going off memory.

- I replaced the "begin, release, reset" transitions with "trigger, release". You can (re)trigger or release from all the expected states.
- Built an envelope visualizer example to help debug, but its probably useful to see how different tweens look!
- From building the visualizer I found a bug in the tween `interpolate` function!