### PR TITLE
simplification of directed graph, small tweaks to fsm & ecs

### DIFF
--- a/junk-drawer/directed-graph.janet
+++ b/junk-drawer/directed-graph.janet
@@ -24,7 +24,7 @@ graph objects metatable if you prefer a OoP style.
 check out the docs on any of those macros/functions for more.
 ```)
 
-(defmacro node
+(defn node
   ```
   Create a node to be used in the "create" or "add-node" functions. Provide
   the node name, and any number of key value pairs for the node data. Name
@@ -35,12 +35,9 @@ check out the docs on any of those macros/functions for more.
     :b (fn [] "hotdog"))
   ```
   [name & properties]
+  [:node (keyword name) {:edges @{} :data (table ;properties)}])
 
-  (if (keyword? name)
-    ~[:node ,(keyword name) ,{:edges @{} :data (table ;properties)}]
-      (error "name must be a keyword")))
-
-(defmacro edge
+(defn edge
   ```
   Create an edge to be used in the "create" or "add-edge" functions. Can be
   any of these forms. note that weight defaults to 1, and the edge name defaults
@@ -52,19 +49,18 @@ check out the docs on any of those macros/functions for more.
   - (edge :from-node :to-node)
   ```
   [& pattern]
-
   (match pattern
     [(name (keyword? name)) (from (keyword? from)) (to (keyword? to)) (weight (number? weight))]
-    ~[:edge ,from {:to ,to :name ,name :weight ,weight}]
+    [:edge from {:to to :name name :weight weight}]
 
     [(name (keyword? name)) (from (keyword? from)) (to (keyword? to))]
-    ~[:edge ,from {:to ,to :name ,name :weight 1}]
+    [:edge from {:to to :name name :weight 1}]
 
     [(from (keyword? from)) (to (keyword? to)) (weight (number? weight))]
-    ~[:edge ,from {:to ,to :name ,to :weight ,weight}]
+    [:edge from {:to to :name to :weight weight}]
 
     [(from (keyword? from)) (to (keyword? to))]
-    ~[:edge ,from {:to ,to :name ,to :weight 1}]))
+    [:edge from {:to to :name to :weight 1}]))
 
 (defn contains [self name]
   ```

--- a/junk-drawer/ecs.janet
+++ b/junk-drawer/ecs.janet
@@ -88,7 +88,7 @@ This implimentation uses a (relatively naive) sparse set data structure.
   ~(def ,name
      (tuple
        ,(values queries)
-       (fn [,;(keys queries) dt] ,;body))))
+       (fn ,name [,;(keys queries) dt] ,;body))))
 
 (defn- get-or-create-component-set
   "return the sparse set for the component, creating if it it does not already exist."

--- a/junk-drawer/fsm.janet
+++ b/junk-drawer/fsm.janet
@@ -9,16 +9,19 @@ This module extends the directed-graph. The main way you'll use it is with
 Check out the docs of that fn for more!
 ```)
 
+(defn- get-current-state [self]
+  (:get-node self (self :current)))
+
 (defn- current-node-call [self fn-name & args]
   ""
-  (when-let [current-node (:get-node self (self :current))
+  (when-let [current-node (:get-current-state self)
              node-fn (get-in current-node [:data fn-name] nil)
              leave-exists (not (nil? node-fn))]
     (node-fn self ;args)))
 
 (defn- apply-edges-functions [self]
   "Create functions on self for each edge in the current node"
-  (when-let [current-node (:get-node self (self :current))
+  (when-let [current-node (:get-current-state self)
              edges (current-node :edges)]
     (each (edge-name edge) (pairs edges)
       (put self edge-name
@@ -34,7 +37,7 @@ Check out the docs of that fn for more!
   (put self :current-data-keys @[])
 
   # apply data to root of fsm
-  (let [current-node (:get-node self (self :current))
+  (let [current-node (:get-current-state self)
         {:data data} current-node]
     (each (key val) (pairs data)
       (array/push (self :current-data-keys) key)
@@ -64,6 +67,7 @@ Check out the docs of that fn for more!
          @{:current @{}
            :current-data-keys @[]
            :visited @{}
+           :get-current-state get-current-state
            :current-node-call current-node-call
            :apply-edges-functions apply-edges-functions
            :apply-data-to-root apply-data-to-root

--- a/junk-drawer/fsm.janet
+++ b/junk-drawer/fsm.janet
@@ -75,11 +75,11 @@ Check out the docs of that fn for more!
   (table/setproto (digraph/create ;states)
                   FSM))
 
-(defmacro transition [& args] ~(as-macro ,digraph/edge ,;args))
-(defmacro state [& args] ~(as-macro ,digraph/node ,;args))
+(def state digraph/node)
+(def transition digraph/edge)
 (defmacro def-state [name & args]
   ~(def ,(symbol name)
-     (as-macro ,state ,(keyword name) ,;args)))
+     (,state ,(keyword name) ,;args)))
 
 (defmacro define
   ```

--- a/junk-drawer/gamestate.janet
+++ b/junk-drawer/gamestate.janet
@@ -9,8 +9,8 @@ between states.
 this module is a thin extension to the Finite state machine.
 ```)
 
-(defmacro transition [& args] ~(as-macro ,fsm/transition ,;args))
-(defmacro state [& args] ~(as-macro ,fsm/state ,;args))
+(def state fsm/state)
+(def transition fsm/transition)
 (defmacro def-state [& args] ~(as-macro ,fsm/def-state ,;args))
 
 (defn- update

--- a/test/unit/directed-graph-test.janet
+++ b/test/unit/directed-graph-test.janet
@@ -59,3 +59,18 @@
                   [:b :d :e :e2g :c :f])
                "should find correct path"))
 (test/end-suite)
+
+# Test if we can use forms for node data and edges info
+(test/start-suite 2)
+(let [data @{:a "pizza" :b "hotdog"}
+      new-node (node :a ;(kvs data))]
+  (test/assert (= (get-in new-node [2 :data :a]) "pizza")
+               "should have spliced data correctly"))
+
+(let [name :pizza
+      from :a
+      to :b
+      new-edge (edge name from to)]
+  (test/assert (= new-edge [:edge :a {:name :pizza :to :b :weight 1}]))
+  )
+(test/end-suite)


### PR DESCRIPTION
- converts `edge` and `node` macros to plain old functions. This is conceptually simpler, and allows for forms to be used as values. Check out the new tests to see examples of this
- ECS `def-system` now passes the name to the inner functions, which makes debugging easier
- FSM has a new `get-current-state` function 

