### PR TITLE
Update 04-gamestates.janet

### DIFF
--- a/examples/04-gamestates.janet
+++ b/examples/04-gamestates.janet
@@ -18,7 +18,7 @@
 (:add-state *GS* menu)
 (:add-state *GS* game)
 (:add-edge *GS* (gamestate/transition :start-game :menu :game))
-(:add-edge *GS* (gamestate/transition :back-to-menu :menu :game))
+(:add-edge *GS* (gamestate/transition :back-to-menu :game :menu))
 
 (:goto *GS* :menu)
 (:update *GS* dt)


### PR DESCRIPTION
Fix broken example of gamestates

Running as-is gives this error:

```console
$ janet examples/04-gamestates.janet
menu init
menu enter ()
menu game state dt: 0
switching to game
game init
game game state dt: 1
Lets go back to the menu
error: unknown method :back-to-menu invoked on <table 0x55E56A3BB2C0>
  in _thunk [examples/04-gamestates.janet] (tailcall) on line 33, column 1
```

With proposed change this example no longer errors out:

```console
$ janet examples/04-gamestates.janet
menu init
menu enter ()
menu game state dt: 0
switching to game
game init
game game state dt: 1
Lets go back to the menu
game leave
menu enter ()
menu game state dt: 2
```