### PR TITLE
Add `:drop-edge` and `:drop-node` methods for digraphs

### DIFF
--- a/examples/02-directed-graph.janet
+++ b/examples/02-directed-graph.janet
@@ -38,5 +38,11 @@
 (printf "does the graph contain the newly added node? %q" (:contains *graph* :c2))
 (printf "neighbors for node C: %q" (:neighbors *graph* :c))
 
+# you can also remove the nodes or edges if you don't want them any more 
+(:drop-edge *graph* :c2)
+(printf "neighbors for node C are different now: %q" (:neighbors *graph* :c))
+(:drop-node *graph* :c2)
+(printf "does the graph contain the previously added node? %q" (:contains *graph* :c2))
+
 # you can even find the path (really the edges) from one node to another
 (printf "edges to get from node A to node I: %q" (:find-path *graph* :a :i))

--- a/junk-drawer/directed-graph.janet
+++ b/junk-drawer/directed-graph.janet
@@ -95,6 +95,27 @@ check out the docs on any of those macros/functions for more.
         (put-in self [:adjacency-table from :edges name]
                 {:to to :weight weight})))
 
+(defn drop-edge 
+  ```
+  Remove an edge from the graph.
+  ```
+  [self name]
+  (eachk node (self :adjacency-table)
+    (put-in self [:adjacency-table node :edges name] nil)))
+
+(defn drop-node 
+  ```
+  Remove a node and all edges related to it from a graph.
+  ```
+  [self name]
+  
+  (put-in self [:adjacency-table name] nil)
+
+  (eachk node (self :adjacency-table)
+    (eachk edge (((self :adjacency-table) node) :edges)
+      (when (= name (get-in self [:adjacency-table node :edges edge :to]))
+        (put-in self [:adjacency-table node :edges edge] nil)))))
+
 (defn neighbors
   ```
   Return all the neighbors of the node, in the form {:from :name :to :weight}
@@ -203,6 +224,8 @@ check out the docs on any of those macros/functions for more.
   @{:contains contains
     :add-node add-node
     :add-edge add-edge
+    :drop-node drop-node
+    :drop-edge drop-edge 
     :get-node get-node
     :neighbors neighbors
     :list-nodes list-nodes


### PR DESCRIPTION
It seems like sometimes one might need to _remove_ nodes and edges from a digraph as well as adding them. These new methods accomplish that (while also, in the case of `:drop-node`, doing cleanup on other nodes' edges to remove any that once pointed to the now-nonexistent node).

All tests pass, including four new suites covering the new features. Also expanded the example file to include `:drop-edge` and `:drop-node`.